### PR TITLE
Allow repositories to be marked as final

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use BitBag\CodingStandard\Fixer\FinalClassInEntitiesOrRepositoriesFixer;
+use BitBag\CodingStandard\Fixer\FinalClassInEntitiesFixer;
 use BitBag\CodingStandard\Fixer\AboveTwoArgumentsMultilineFixer;
 use PhpCsFixer\Fixer\Alias\EregToPregFixer;
 use PhpCsFixer\Fixer\Alias\NoAliasFunctionsFixer;
@@ -391,9 +391,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(RequireOneLinePropertyDocCommentSniff::class);
 
     $services->set(YodaStyleFixer::class)->call('configure',[['equal' => true, 'identical' => true, 'less_and_greater' => true,]]);
-    
-    $services->set(FinalClassInEntitiesOrRepositoriesFixer::class);
-  
+
+    $services->set(FinalClassInEntitiesFixer::class);
+
     $services->set(AboveTwoArgumentsMultilineFixer::class);
 };
-

--- a/src/Fixer/FinalClassInEntitiesFixer.php
+++ b/src/Fixer/FinalClassInEntitiesFixer.php
@@ -11,7 +11,7 @@ use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 
-final class FinalClassInEntitiesOrRepositoriesFixer implements FixerInterface
+final class FinalClassInEntitiesFixer implements FixerInterface
 {
     public function isCandidate(Tokens $tokens): bool
     {
@@ -42,13 +42,13 @@ final class FinalClassInEntitiesOrRepositoriesFixer implements FixerInterface
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Repositories and Entities should not be defined as final.',
+            'Entities should not be defined as final.',
             [
                 new CodeSample(
                     '<?php
                            declare(strict_types=1);
                            namespace App\Entity;
-                           final class Product
+                           class Product
                            {
                            }
                            '
@@ -69,6 +69,6 @@ final class FinalClassInEntitiesOrRepositoriesFixer implements FixerInterface
 
     public function supports(SplFileInfo $file): bool
     {
-        return str_contains($file->getPath(), 'src/Entity') || str_contains($file->getPath(), 'src/Repository');
+        return str_contains($file->getPath(), 'src/Entity');
     }
 }

--- a/src/Fixer/FinalClassInEntitiesFixer.php
+++ b/src/Fixer/FinalClassInEntitiesFixer.php
@@ -48,7 +48,7 @@ final class FinalClassInEntitiesFixer implements FixerInterface
                     '<?php
                            declare(strict_types=1);
                            namespace App\Entity;
-                           class Product
+                           final class Product
                            {
                            }
                            '

--- a/src/Fixer/FinalClassInEntitiesFixer.php
+++ b/src/Fixer/FinalClassInEntitiesFixer.php
@@ -69,6 +69,6 @@ final class FinalClassInEntitiesFixer implements FixerInterface
 
     public function supports(SplFileInfo $file): bool
     {
-        return str_contains($file->getPath(), 'src/Entity');
+        return strpos($file->getFilename(), 'src/Entity') !== false;
     }
 }

--- a/src/Fixer/FinalClassInEntitiesFixer.php
+++ b/src/Fixer/FinalClassInEntitiesFixer.php
@@ -69,6 +69,6 @@ final class FinalClassInEntitiesFixer implements FixerInterface
 
     public function supports(SplFileInfo $file): bool
     {
-        return strpos($file->getFilename(), 'src/Entity') !== false;
+        return strpos($file->getPath(), 'src/Entity') !== false;
     }
 }


### PR DESCRIPTION
This PR makes repositories allowed to be marked as final. Also I've replaced `str_contains` introduced in PHP 8.0 with `strpos` to keep an compatibility with earlier versions.