### PR TITLE
OPSRC-442 PHPStan update

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 };
 
 ```
-
+Then create `phpstan.neon` file with the following lines or add include line at the beginning of your existing file if you have one
+```neon
+includes:
+    - vendor/bitbag/coding-standard/phpstan.neon
+```
 
 ## Usage
 
@@ -79,6 +83,11 @@ If ECS found any standard violations, you can fix it by:
 ```bash
 ./vendor/bin/ecs check src --fix
 ```
+To check /src dir by PHPStan:
+```bash
+./vendor/bin/phpstan analyse src
+```
+
 ## Customization
 
 #### ECS
@@ -94,10 +103,20 @@ $services->set(FooBarFixer::class);
 #### PHPStan
 You can set PHPStan rule level with following commands
 ```bash
-./vendor/bin/phpstan analyze --configuration=vendor/bitbag/coding-standard/phpstan.neon src --level=8
-./vendor/bin/phpstan analyze --configuration=vendor/bitbag/coding-standard/phpstan.neon tests --level=5
+./vendor/bin/phpstan analyze src --level=8
+./vendor/bin/phpstan analyze tests --level=5
 ```
+or you can customize configuration in `phpstan.neon` file
+```neon
+includes:
+    - vendor/bitbag/coding-standard/phpstan.neon
 
+parameters:
+    level: max
+    paths:
+        - src
+        - tests
+```
 
 # About us
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,15 +4,15 @@ parameters:
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
 
-    excludes_analyse:
+    excludePaths:
         # Makes PHPStan crash
-        - 'src/DependencyInjection/Configuration.php'
+        - '../../../src/DependencyInjection/Configuration.php'
 
         # Test dependencies
-        - 'tests/Application/app/**.php'
-        - 'tests/Application/src/**.php'
+        - '../../../tests/Application/*'
 
-        # ECS Fixer dependency
-        - 'src/Fixer'
+        # BitBag coding standard dependencies
+        - 'src/*'
+
     ignoreErrors:
         - '/Parameter #1 \$configuration of method Symfony\\Component\\DependencyInjection\\Extension\\Extension::processConfiguration\(\) expects Symfony\\Component\\Config\\Definition\\ConfigurationInterface, Symfony\\Component\\Config\\Definition\\ConfigurationInterface\|null given\./'


### PR DESCRIPTION
I've updated phpstan.neon configuration and readme (to use `include`), but you can still use the old method with passing configuration file in cli:
`./vendor/bin/phpstan analyze src -c vendor/bitbag/coding-standard/phpstan.neon`
or you can still override entire phpstan.neon file, so it's not breaking backward compatibility