### PR TITLE
OPSRC 679 Add OS Header to ECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ use Symplify\EasyCodingStandard\ValueObject\Option;
 return static function (ContainerConfigurator $containerConfigurator): void {
 
     // Change this if you don't want to automatically add BitBag OpenSource Header
-    putenv('ALLOW_BITBAG_OS_HEADER=1');
+    putenv('ALLOW_BITBAG_OS_HEADER=0');
     
     $containerConfigurator->import('vendor/bitbag/coding-standard/ecs.php');
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ use Symplify\EasyCodingStandard\ValueObject\Option;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
 
-    // Change this if you want to automatically add BitBag OpenSource Header
-    putenv('ALLOW_BITBAG_OS_HEADER=0');
+    // Change this if you don't want to automatically add BitBag OpenSource Header
+    putenv('ALLOW_BITBAG_OS_HEADER=1');
     
     $containerConfigurator->import('vendor/bitbag/coding-standard/ecs.php');
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Symplify\EasyCodingStandard\ValueObject\Option;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+
+    // Change this if you want to automatically add BitBag OpenSource Header
+    putenv('ALLOW_BITBAG_OS_HEADER=0');
+    
     $containerConfigurator->import('vendor/bitbag/coding-standard/ecs.php');
 
     $parameters = $containerConfigurator->parameters();

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ use Symplify\EasyCodingStandard\ValueObject\Option;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
 
-    // Change this if you don't want to automatically add BitBag OpenSource Header
+    // Change this if you want to automatically add BitBag OpenSource Header
     putenv('ALLOW_BITBAG_OS_HEADER=0');
     
     $containerConfigurator->import('vendor/bitbag/coding-standard/ecs.php');

--- a/ecs.php
+++ b/ecs.php
@@ -38,6 +38,7 @@ use PhpCsFixer\Fixer\ClassNotation\ProtectedToPrivateFixer;
 use PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer;
 use PhpCsFixer\Fixer\ClassNotation\SingleClassElementPerStatementFixer;
 use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
+use PhpCsFixer\Fixer\Comment\HeaderCommentFixer;
 use PhpCsFixer\Fixer\Comment\NoEmptyCommentFixer;
 use PhpCsFixer\Fixer\Comment\NoTrailingWhitespaceInCommentFixer;
 use PhpCsFixer\Fixer\Comment\SingleLineCommentStyleFixer;

--- a/ecs.php
+++ b/ecs.php
@@ -397,13 +397,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(AboveTwoArgumentsMultilineFixer::class);
 
-    $services
-        ->set(HeaderCommentFixer::class)
-        ->call('configure', [[
-            "header" => "This file has been created by developers from BitBag. \nFeel free to contact us once you face any issues or want to start\nYou can find more information about us on https://bitbag.io and write us\nan email on hello@bitbag.io.",
-            "location" => "after_open"]]);
+    if (!in_array(getenv('ALLOW_BITBAG_OS_HEADER'), [false, 0, '0'], true)) {
+        $services
+            ->set(HeaderCommentFixer::class)
+            ->call('configure', [[
+                "header" => "This file has been created by developers from BitBag. \nFeel free to contact us once you face any issues or want to start\nYou can find more information about us on https://bitbag.io and write us\nan email on hello@bitbag.io.",
+                "location" => "after_open"]]);
 
-    $parameters = $containerConfigurator->parameters();
+        $parameters = $containerConfigurator->parameters();
 
-    $parameters->set('skip', [HeaderCommentFixer::class => ['Kernel.php', 'Migrations/*']]);
+        $parameters->set('skip', [HeaderCommentFixer::class => ['Kernel.php', 'Migrations/*']]);
+    }
 };

--- a/ecs.php
+++ b/ecs.php
@@ -395,4 +395,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(FinalClassInEntitiesFixer::class);
 
     $services->set(AboveTwoArgumentsMultilineFixer::class);
+
+    $services
+        ->set(HeaderCommentFixer::class)
+        ->call('configure', [[
+            "header" => "This file has been created by developers from BitBag. \nFeel free to contact us once you face any issues or want to start\nYou can find more information about us on https://bitbag.io and write us\nan email on hello@bitbag.io.",
+            "location" => "after_open"]]);
+
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set('skip', [HeaderCommentFixer::class => ['Kernel.php', 'Migrations/*']]);
 };


### PR DESCRIPTION
- Adds BitBag OS Header to ECS
- Excludes Migrations directory and Kernel.php file from using header rule