### PR TITLE
Replace deprecated parameters with errors identifiers

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,6 @@
 parameters:
     level: 8
     reportUnmatchedIgnoredErrors: false
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
 
     excludePaths:
         # Makes PHPStan crash
@@ -16,3 +14,7 @@ parameters:
 
     ignoreErrors:
         - '/Parameter #1 \$configuration of method Symfony\\Component\\DependencyInjection\\Extension\\Extension::processConfiguration\(\) expects Symfony\\Component\\Config\\Definition\\ConfigurationInterface, Symfony\\Component\\Config\\Definition\\ConfigurationInterface\|null given\./'
+        -
+            identifier: missingType.iterableValue
+        -
+            identifier: missingType.generics


### PR DESCRIPTION
This PR replacing deprecated config parameters with error identifier keys to avoid facing those messages:
![Screenshot 2025-05-26 at 11 04 09](https://github.com/user-attachments/assets/f823bcf7-63e0-407f-b5e6-60fbd4e4c1d9)
